### PR TITLE
feat: Add `iroh-router` support & optional in-memory rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,6 +2282,7 @@ dependencies = [
  "iroh-io",
  "iroh-metrics",
  "iroh-net",
+ "iroh-router",
  "iroh-test",
  "meadowcap",
  "nested_enum_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
+checksum = "dc623a188942fc875926f7baeb2cb08ed4288b64f29072656eb051e360ee7623"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3427,6 +3427,7 @@ dependencies = [
  "serde",
  "slab",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ iroh-blobs = { version = "0.28.0" }
 iroh-io = { version = "0.6.0", features = ["stats"] }
 iroh-metrics = { version = "0.28.0", optional = true }
 iroh-net = { version = "0.28.0" }
+iroh-router = "0.28.0"
 meadowcap = "0.1.0"
 nested_enum_utils = "0.1.0"
 postcard = { version = "1", default-features = false, features = [ "alloc", "use-std", "experimental-derive", ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ iroh-net = { version = "0.28.0" }
 meadowcap = "0.1.0"
 nested_enum_utils = "0.1.0"
 postcard = { version = "1", default-features = false, features = [ "alloc", "use-std", "experimental-derive", ] }
-quic-rpc = "0.15.0"
+quic-rpc = "0.15.1"
 quic-rpc-derive = "0.15.0"
 rand = "0.8.5"
 rand_core = "0.6.4"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,7 @@
 //! Engine for driving a willow store and synchronisation sessions.
 
+use std::sync::{Arc, OnceLock};
+
 use anyhow::Result;
 use futures_util::{
     future::{MapErr, Shared},
@@ -14,6 +16,7 @@ use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, error_span, Instrument};
 
 use crate::{
+    rpc::{client::MemClient, handler::RpcHandler},
     session::{
         intents::{Intent, IntentHandle},
         SessionInit,
@@ -39,6 +42,7 @@ const PEER_MANAGER_INBOX_CAP: usize = 128;
 #[derive(Debug, Clone)]
 pub struct Engine {
     actor_handle: ActorHandle,
+    pub(crate) endpoint: Endpoint,
     peer_manager_inbox: mpsc::Sender<peer_manager::Input>,
     // `Engine` needs to be `Clone + Send`, and we need to `task.await` in its `shutdown()` impl.
     // So we need
@@ -47,11 +51,20 @@ pub struct Engine {
     // - `AbortOnDropHandle` to make sure that the `task` is cancelled when all `Node`s are dropped
     //   (`Shared` acts like an `Arc` around its inner future).
     peer_manager_task: Shared<MapErr<AbortOnDropHandle<Result<(), String>>, JoinErrToStr>>,
+    rpc_handler: Arc<OnceLock<crate::rpc::handler::RpcHandler>>,
 }
 
 pub(crate) type JoinErrToStr = Box<dyn Fn(JoinError) -> String + Send + Sync + 'static>;
 
 impl Engine {
+    /// Get an in memory client to interact with the willow engine.
+    pub fn client(&self) -> &MemClient {
+        &self
+            .rpc_handler
+            .get_or_init(|| RpcHandler::new(self.clone()))
+            .client
+    }
+
     /// Start the Willow engine.
     ///
     /// This needs an `endpoint` to connect to other peers, and a `create_store` closure which
@@ -74,8 +87,12 @@ impl Engine {
         let me = endpoint.node_id();
         let actor_handle = ActorHandle::spawn(create_store, me);
         let (pm_inbox_tx, pm_inbox_rx) = mpsc::channel(PEER_MANAGER_INBOX_CAP);
-        let peer_manager =
-            PeerManager::new(actor_handle.clone(), endpoint, pm_inbox_rx, accept_opts);
+        let peer_manager = PeerManager::new(
+            actor_handle.clone(),
+            endpoint.clone(),
+            pm_inbox_rx,
+            accept_opts,
+        );
         let peer_manager_task = tokio::task::spawn(
             async move { peer_manager.run().await.map_err(|e| e.to_string()) }
                 .instrument(error_span!("peer_manager", me=%me.fmt_short())),
@@ -85,8 +102,10 @@ impl Engine {
             .shared();
         Engine {
             actor_handle,
+            endpoint,
             peer_manager_inbox: pm_inbox_tx,
             peer_manager_task,
+            rpc_handler: Default::default(),
         }
     }
 


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
- Adds `Engine::client` fn that returns an in-memory RPC client
- Adds `impl ProtocolHandler for Engine` so iroh-willow can be used with iroh-router
- Moved a reference to `Endpoint` into `Engine`, so it can be used when answering RPC requests like `add_node_addr` or `node_addr`

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
