### PR TITLE
chore: Use main branch of `willow-store`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "willow-store"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/willow-store.git?branch=matheus23/redb-ref#3a29c592fe071ff87fa763bd4650bfed789a53e6"
+source = "git+https://github.com/n0-computer/willow-store.git?branch=main#f7c44af52e06605543d7e403aa57aeb9e1afd087"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tracing = "0.1"
 ufotofu = { version = "0.4.1", features = ["std"] }
 willow-data-model = "0.1.0"
 willow-encoding = "0.1.0"
-willow-store = { git = "https://github.com/n0-computer/willow-store.git", branch = "matheus23/redb-ref" }
+willow-store = { git = "https://github.com/n0-computer/willow-store.git", branch = "main" }
 zerocopy = { version = "0.7", features = ["derive"] }
 zerocopy-derive = "0.7"
 data-encoding = "2.6.0"


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
We used to depend on `matheus23/redb-ref`, but that's merged now (and the branch is deleted).


## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
