### PR TITLE
chore(ci): Mark `owned_namespace_subspace_write_sync` as flaky

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -313,6 +313,7 @@ async fn read_back_write() -> Result<()> {
     Ok(())
 }
 
+#[ignore = "flaky"]
 #[tokio::test(flavor = "multi_thread")]
 async fn owned_namespace_subspace_write_sync() -> Result<()> {
     iroh_test::logging::setup_multithreaded();


### PR DESCRIPTION
## Description

This test seems to be flaky, it failed here: https://github.com/n0-computer/iroh-willow/actions/runs/14439335190/job/40485927850

It seemed to hang or might also have just run long, not sure:
> `     TIMEOUT [  60.015s] iroh-willow::basic owned_namespace_subspace_write_sync`
